### PR TITLE
[gitpod] improved config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,8 @@ image:
 ports:
     - port: 3000
       onOpen: open-preview
+    - port: 3306
+      onOpen: ignore
 tasks:
     - init: >
         cp .env.example .env;
@@ -11,5 +13,7 @@ tasks:
         pipenv run init;
         pipenv run migrate;
         pipenv run upgrade;
+      command: >
         pipenv run start;
     - command: python3 welcome.py
+      openMode: split-right

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flask Boilerplate for Profesional Development
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/4GeeksAcademy/flask-rest-hello.git)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Features
 


### PR DESCRIPTION
minor improvements to the gitpod config. Most important is the splitting of the init task. As the last command is not terminating and therefore should go as a `command`. Tasks `init` are executed during prebuild, so they need to terminate.