### PR TITLE
Update DEPLOY_PUBLISH_YOUR_APP.md

### DIFF
--- a/docs/DEPLOY_PUBLISH_YOUR_APP.md
+++ b/docs/DEPLOY_PUBLISH_YOUR_APP.md
@@ -16,6 +16,10 @@ $ heroku login -i
 ```sh
 $ heroku create <your_application_name>
 ```
+4. Change the heroku stack version to heroku-20 to make it work with this boilerplate (if you don't have it already)
+```sh
+$ heroku stack:set heroku-20
+```
 
 ## Enviroment Variables (takes 2 minutes)
 


### PR DESCRIPTION
Heroku-22 stack is used my default when the heroku cli is installed. Heroku-22 stack does NOT support python 3.7.15 which is the version being used by the boilerplate to set up the virtual environment. Setting the version to heroku-20 is necessary for everything to work properly.

More information here: https://devcenter.heroku.com/articles/python-support#supported-runtimes